### PR TITLE
Escaped string that may contain regex modifiers

### DIFF
--- a/lib/App/iosdiff.pm
+++ b/lib/App/iosdiff.pm
@@ -132,7 +132,7 @@ sub generate_lookups {
 
         if ("$key1 $key2" ne $stanza and $i < $#lines) {
             $stanza = $key1;
-            $stanza = "$key1 $key2" if $lines[$i+1] =~ m/^$key1 $key2/;
+            $stanza = "$key1 $key2" if $lines[$i+1] =~ m/^\Q$key1\E \Q$key2\E/;
         }
         else {
             # last line special case


### PR DESCRIPTION
This addresses #1 when stanzas contain characters that look like regex modifiers.
